### PR TITLE
Normalise Gym video frames between [-1, 1]

### DIFF
--- a/Chapter03/03_atari_gan.py
+++ b/Chapter03/03_atari_gan.py
@@ -49,7 +49,7 @@ class InputWrapper(gym.ObservationWrapper):
         new_obs = cv2.resize(observation, (IMAGE_SIZE, IMAGE_SIZE))
         # transform (210, 160, 3) -> (3, 210, 160)
         new_obs = np.moveaxis(new_obs, 2, 0)
-        return new_obs.astype(np.float32) / 255.0
+        return new_obs.astype(np.float32)
 
 
 class Discriminator(nn.Module):
@@ -122,7 +122,9 @@ def iterate_batches(envs, batch_size=BATCH_SIZE):
         if np.mean(obs) > 0.01:
             batch.append(obs)
         if len(batch) == batch_size:
-            yield torch.tensor(np.array(batch, dtype=np.float32))
+            # Normalising input between -1 to 1
+            batch_np = (np.array(batch, dtype=np.float32) - 127.5) / 127.5
+            yield torch.tensor(batch_np)
             batch.clear()
         if is_done:
             e.reset()


### PR DESCRIPTION
Since the generator outputs values between (-1, 1)( because of tanh), I think its also better than the Game video frames are normalized between [-1, 1] instead of  [0, 1] (since you divide them by 255.0). The Generator loss is much more stable(Light blue in the picture below) after this and after 40-50K, the results are much better.
Additionally, changing ReLU to LeakyReLU gave better results but I haven't changed that to avoid confusion of people reading the book and watching the code.
![gen_loss](https://user-images.githubusercontent.com/9641196/49332259-0757d700-f5d0-11e8-8086-cec4036a471f.png)
