### PR TITLE
Upgrade tensorboardX to 1.6 to avoid failure without cuda

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ opencv-python==3.4.3.18
 scipy==1.1.0
 torch==0.4.1
 torchvision==0.2.1
-tensorboard-pytorch==0.7.1
+tensorboardX==1.6
 tensorflow==1.12.0
 tensorboard==1.12.0
 pybullet==2.3.6


### PR DESCRIPTION
tensorboard-pytorch has been renamed to tensorboardX. The old version(0.7.1) would crash when I run Chapter03/03_atari_gan.py without cuda.

When calling ` writer.add_image("fake", vutils.make_grid(gen_output_v.data[:64], normalize=True), iter_no)`, it raises an error which says `'input tensor should be one of numpy.ndarray, torch.cuda.FloatTensor, torch.FloatTensor'`. But without cuda, the tensor type is `torch.Tensor`.

The latest version of tensorboardX has fixed this issue.