### PR TITLE
Added tensorboardX to the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+tensorboardX
 numpy==1.15.4
 atari-py==0.1.6
 gym==0.10.9


### PR DESCRIPTION
I added the tensorboardX to the requirements.txt.
Chapter04/01_cartpole.py requires tensorboardX for example.
I am not sure which version is required so left it blank.