### PR TITLE
np.uint8 to np.bool

### DIFF
--- a/Chapter06/02_dqn_pong.py
+++ b/Chapter06/02_dqn_pong.py
@@ -46,7 +46,7 @@ class ExperienceBuffer:
         indices = np.random.choice(len(self.buffer), batch_size, replace=False)
         states, actions, rewards, dones, next_states = zip(*[self.buffer[idx] for idx in indices])
         return np.array(states), np.array(actions), np.array(rewards, dtype=np.float32), \
-               np.array(dones, dtype=np.uint8), np.array(next_states)
+               np.array(dones, dtype=np.bool), np.array(next_states)
 
 
 class Agent:

--- a/Chapter06/lib/wrappers.py
+++ b/Chapter06/lib/wrappers.py
@@ -57,7 +57,7 @@ class MaxAndSkipEnv(gym.Wrapper):
 class ProcessFrame84(gym.ObservationWrapper):
     def __init__(self, env=None):
         super(ProcessFrame84, self).__init__(env)
-        self.observation_space = gym.spaces.Box(low=0, high=255, shape=(84, 84, 1), dtype=np.uint8)
+        self.observation_space = gym.spaces.Box(low=0, high=255, shape=(84, 84, 1), dtype=np.bool)
 
     def observation(self, obs):
         return ProcessFrame84.process(obs)
@@ -74,7 +74,7 @@ class ProcessFrame84(gym.ObservationWrapper):
         resized_screen = cv2.resize(img, (84, 110), interpolation=cv2.INTER_AREA)
         x_t = resized_screen[18:102, :]
         x_t = np.reshape(x_t, [84, 84, 1])
-        return x_t.astype(np.uint8)
+        return x_t.astype(np.bool)
 
 
 class ImageToPyTorch(gym.ObservationWrapper):


### PR DESCRIPTION
`/pytorch/aten/src/ATen/native/IndexingUtils.h:20: UserWarning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.`

this solves the above warning.