### PR TITLE
Fixed 02_pong_a2c.py and speed up the convergence/process

### DIFF
--- a/Chapter10/02_pong_a2c.py
+++ b/Chapter10/02_pong_a2c.py
@@ -78,12 +78,12 @@ def unpack_batch(batch, net, device='cpu'):
         if exp.last_state is not None:
             not_done_idx.append(idx)
             last_states.append(np.array(exp.last_state, copy=False))
-    states_v = torch.FloatTensor(states).to(device)
+    states_v = torch.FloatTensor(np.array(states, copy=False)).to(device)
     actions_t = torch.LongTensor(actions).to(device)
     # handle rewards
     rewards_np = np.array(rewards, dtype=np.float32)
     if not_done_idx:
-        last_states_v = torch.FloatTensor(last_states).to(device)
+        last_states_v = torch.FloatTensor(np.array(last_states, copy)).to(device)
         last_vals_v = net(last_states_v)[1]
         last_vals_np = last_vals_v.data.cpu().numpy()[:, 0]
         rewards_np[not_done_idx] += GAMMA ** REWARD_STEPS * last_vals_np
@@ -135,7 +135,7 @@ if __name__ == "__main__":
                 loss_value_v = F.mse_loss(value_v.squeeze(-1), vals_ref_v)
 
                 log_prob_v = F.log_softmax(logits_v, dim=1)
-                adv_v = vals_ref_v - value_v.detach()
+                adv_v = vals_ref_v - value_v.squeeze(-1).detach()
                 log_prob_actions_v = adv_v * log_prob_v[range(BATCH_SIZE), actions_t]
                 loss_policy_v = -log_prob_actions_v.mean()
 

--- a/Chapter10/02_pong_a2c.py
+++ b/Chapter10/02_pong_a2c.py
@@ -131,7 +131,6 @@ if __name__ == "__main__":
                 batch.clear()
 
                 optimizer.zero_grad()
-                import ipdb; ipdb.set_trace()
                 logits_v, value_v = net(states_v)
                 loss_value_v = F.mse_loss(value_v.squeeze(-1), vals_ref_v)
 

--- a/Chapter10/02_pong_a2c.py
+++ b/Chapter10/02_pong_a2c.py
@@ -83,7 +83,7 @@ def unpack_batch(batch, net, device='cpu'):
     # handle rewards
     rewards_np = np.array(rewards, dtype=np.float32)
     if not_done_idx:
-        last_states_v = torch.FloatTensor(np.array(last_states, copy)).to(device)
+        last_states_v = torch.FloatTensor(np.array(last_states, copy=False)).to(device)
         last_vals_v = net(last_states_v)[1]
         last_vals_np = last_vals_v.data.cpu().numpy()[:, 0]
         rewards_np[not_done_idx] += GAMMA ** REWARD_STEPS * last_vals_np
@@ -131,6 +131,7 @@ if __name__ == "__main__":
                 batch.clear()
 
                 optimizer.zero_grad()
+                import ipdb; ipdb.set_trace()
                 logits_v, value_v = net(states_v)
                 loss_value_v = F.mse_loss(value_v.squeeze(-1), vals_ref_v)
 


### PR DESCRIPTION
I changed the line adv_v = vals_ref_v - value_v.detach() to adv_v = vals_ref_v - value_v.squeeze(-1).detach(). It seems the convergence is much faster. According to the A2C algorithm, it is just logic to apply Q(a, s) - V(s) where Q(a, s) and V(s) with the same shape.

The call to detach() is important here as we don't want to propagate the PG into our value approximation head.

I added np.array() in two places to speed up the process