### PR TITLE
Update 02_dqn_pong.py

### DIFF
--- a/Chapter06/02_dqn_pong.py
+++ b/Chapter06/02_dqn_pong.py
@@ -89,9 +89,9 @@ def calc_loss(batch, net, tgt_net, device="cpu"):
 
     states_v = torch.tensor(states).to(device)
     next_states_v = torch.tensor(next_states).to(device)
-    actions_v = torch.tensor(actions).to(device)
+    actions_v = torch.tensor(actions).to(device=device, dtype=torch.int64)
     rewards_v = torch.tensor(rewards).to(device)
-    done_mask = torch.ByteTensor(dones).to(device)
+    done_mask = torch.tensor(dones).to(device=device,dtype=torch.bool)
 
     state_action_values = net(states_v).gather(1, actions_v.unsqueeze(-1)).squeeze(-1)
     next_state_values = tgt_net(next_states_v).max(1)[0]


### PR DESCRIPTION
As uint8 is depreciated in later versions of pytorch, so instead use torch.bool for indexing the next_state_values. Using uint8 generates a user warning. Also actions_v tensor should be of dtype=torch.int64 to use the gather() .

